### PR TITLE
Use DQN with replay buffer

### DIFF
--- a/MinecraftSelfLearningAI/agent.py
+++ b/MinecraftSelfLearningAI/agent.py
@@ -1,26 +1,88 @@
 import random
-import numpy as np
+from typing import Tuple
 
-class QLearningAgent:
-    def __init__(self, actions, alpha=0.1, gamma=0.9, epsilon=0.2):
-        self.q_table = {}
-        self.actions = actions
-        self.alpha = alpha
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+
+class DQN(nn.Module):
+    """Simple feed-forward network used to approximate Q-values."""
+
+    def __init__(self, input_dim: int, output_dim: int) -> None:
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(input_dim, 128),
+            nn.ReLU(),
+            nn.Linear(128, 64),
+            nn.ReLU(),
+            nn.Linear(64, output_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        return self.layers(x)
+
+
+class DQNAgent:
+    """Deep Q-Network based agent."""
+
+    def __init__(
+        self,
+        state_dim: int,
+        action_dim: int,
+        lr: float = 1e-3,
+        gamma: float = 0.99,
+    ) -> None:
+        self.action_dim = action_dim
         self.gamma = gamma
-        self.epsilon = epsilon
 
-    def get_qs(self, state):
-        if state not in self.q_table:
-            self.q_table[state] = np.zeros(len(self.actions))
-        return self.q_table[state]
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    def choose_action(self, state):
-        if random.random() < self.epsilon:
-            return random.choice(self.actions)
-        return int(np.argmax(self.get_qs(state)))
+        self.policy_net = DQN(state_dim, action_dim).to(self.device)
+        self.target_net = DQN(state_dim, action_dim).to(self.device)
+        self.target_net.load_state_dict(self.policy_net.state_dict())
+        self.target_net.eval()
 
-    def learn(self, state, action, reward, next_state, done):
-        current_q = self.get_qs(state)[action]
-        max_next_q = np.max(self.get_qs(next_state)) if not done else 0
-        new_q = current_q + self.alpha * (reward + self.gamma * max_next_q - current_q)
-        self.q_table[state][action] = new_q
+        self.optimizer = optim.Adam(self.policy_net.parameters(), lr=lr)
+        self.loss_fn = nn.SmoothL1Loss()
+
+    def select_action(self, state: Tuple[int, ...], epsilon: float) -> int:
+        """Epsilon-greedy action selection."""
+        if random.random() < epsilon:
+            return random.randrange(self.action_dim)
+
+        state_t = torch.tensor(state, dtype=torch.float32, device=self.device).unsqueeze(0)
+        with torch.no_grad():
+            q_values = self.policy_net(state_t)
+        return int(torch.argmax(q_values, dim=1).item())
+
+    def train_step(self, batch) -> None:
+        """Update the policy network using a batch of experience."""
+
+        states, actions, rewards, next_states, dones = batch
+
+        states_t = torch.tensor(states, dtype=torch.float32, device=self.device)
+        actions_t = torch.tensor(actions, dtype=torch.long, device=self.device).unsqueeze(1)
+        rewards_t = torch.tensor(rewards, dtype=torch.float32, device=self.device)
+        next_states_t = torch.tensor(next_states, dtype=torch.float32, device=self.device)
+        dones_t = torch.tensor(dones, dtype=torch.float32, device=self.device)
+
+        q_values = self.policy_net(states_t).gather(1, actions_t).squeeze(1)
+
+        with torch.no_grad():
+            next_q_values = self.target_net(next_states_t).max(1)[0]
+            targets = rewards_t + self.gamma * next_q_values * (1 - dones_t)
+
+        loss = self.loss_fn(q_values, targets)
+
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+
+    def update_target(self) -> None:
+        """Synchronize target network with policy network."""
+        self.target_net.load_state_dict(self.policy_net.state_dict())
+
+    def save(self, path: str) -> None:
+        torch.save(self.policy_net.state_dict(), path)
+

--- a/MinecraftSelfLearningAI/replay_buffer.py
+++ b/MinecraftSelfLearningAI/replay_buffer.py
@@ -1,0 +1,31 @@
+import random
+from collections import deque
+from typing import Deque, Tuple
+
+import numpy as np
+
+
+class ReplayBuffer:
+    """Fixed-size buffer to store experience tuples."""
+
+    def __init__(self, capacity: int) -> None:
+        self.buffer: Deque[Tuple[np.ndarray, int, float, np.ndarray, bool]] = deque(maxlen=capacity)
+
+    def push(
+        self,
+        state: Tuple[int, ...],
+        action: int,
+        reward: float,
+        next_state: Tuple[int, ...],
+        done: bool,
+    ) -> None:
+        self.buffer.append((state, action, reward, next_state, done))
+
+    def sample(self, batch_size: int):
+        batch = random.sample(self.buffer, batch_size)
+        states, actions, rewards, next_states, dones = map(np.array, zip(*batch))
+        return states, actions, rewards, next_states, dones
+
+    def __len__(self) -> int:  # pragma: no cover - simple wrapper
+        return len(self.buffer)
+

--- a/MinecraftSelfLearningAI/train.py
+++ b/MinecraftSelfLearningAI/train.py
@@ -1,34 +1,80 @@
-from env import DummyMinecraftEnv
-from agent import QLearningAgent
+"""Training script for a DQN agent in the simple Minecraft-like environment."""
+
 import matplotlib.pyplot as plt
+import numpy as np
 
-env = DummyMinecraftEnv()
-agent = QLearningAgent(actions=[0, 1, 2, 3])
+from agent import DQNAgent
+from env import DummyMinecraftEnv
+from replay_buffer import ReplayBuffer
 
-episodes = 5000
-reward_log = []
 
-for ep in range(episodes):
-    state = env.reset()
-    total_reward = 0
+EPISODES = 100_000
+BUFFER_SIZE = 10_000
+BATCH_SIZE = 64
+GAMMA = 0.99
 
-    while True:
-        action = agent.choose_action(state)
-        next_state, reward, done = env.step(action)
-        agent.learn(state, action, reward, next_state, done)
-        state = next_state
-        total_reward += reward
-        if done:
-            break
+EPS_START = 0.9
+EPS_END = 0.05
+EPS_DECAY_EPISODES = 50_000
 
-    reward_log.append(total_reward)
-    if ep % 500 == 0:
-        print(f"Episode {ep} - Reward: {total_reward:.2f}")
 
-# Plot rewards
-plt.plot(reward_log)
-plt.xlabel("Episode")
-plt.ylabel("Total Reward")
-plt.title("AI Learning Progress")
-plt.savefig("reward_plot.png")
-plt.show()
+def epsilon_by_episode(ep: int) -> float:
+    if ep >= EPS_DECAY_EPISODES:
+        return EPS_END
+    slope = (EPS_END - EPS_START) / EPS_DECAY_EPISODES
+    return EPS_START + slope * (ep - 1)
+
+
+def train() -> None:
+    env = DummyMinecraftEnv()
+    state_dim = len(env.reset())
+    action_dim = 4
+
+    agent = DQNAgent(state_dim, action_dim, gamma=GAMMA)
+    buffer = ReplayBuffer(BUFFER_SIZE)
+
+    rewards: list[float] = []
+
+    for ep in range(1, EPISODES + 1):
+        state = env.reset()
+        total_reward = 0.0
+        done = False
+
+        epsilon = epsilon_by_episode(ep)
+
+        while not done:
+            action = agent.select_action(state, epsilon)
+            next_state, reward, done = env.step(action)
+            buffer.push(state, action, reward, next_state, done)
+            state = next_state
+            total_reward += reward
+
+            if len(buffer) >= BATCH_SIZE:
+                batch = buffer.sample(BATCH_SIZE)
+                agent.train_step(batch)
+
+        rewards.append(total_reward)
+
+        # Periodic updates and logging
+        if ep % 1000 == 0:
+            avg_reward = np.mean(rewards[-1000:])
+            print(f"Episode {ep} - Avg Reward: {avg_reward:.3f}")
+            agent.update_target()
+
+        if ep % 10_000 == 0:
+            agent.save(f"model_ep{ep}.pth")
+
+    # Save final model
+    agent.save("model_final.pth")
+
+    # Plot rewards over episodes
+    plt.plot(rewards)
+    plt.xlabel("Episode")
+    plt.ylabel("Total Reward")
+    plt.title("DQN Training Rewards")
+    plt.savefig("reward_plot.png")
+
+
+if __name__ == "__main__":
+    train()
+


### PR DESCRIPTION
## Summary
- replace tabular Q-learning with PyTorch DQN
- add replay buffer for experience replay
- train 100k episodes with epsilon decay, logging, and model saves

## Testing
- `python -m py_compile agent.py replay_buffer.py train.py`


------
https://chatgpt.com/codex/tasks/task_e_6890583862588331aa331872f76de4d7