### PR TITLE
Save models periodically during training

### DIFF
--- a/MinecraftSelfLearningAI/train.py
+++ b/MinecraftSelfLearningAI/train.py
@@ -60,8 +60,6 @@ def train() -> None:
             avg_reward = np.mean(rewards[-1000:])
             print(f"Episode {ep} - Avg Reward: {avg_reward:.3f}")
             agent.update_target()
-
-        if ep % 10_000 == 0:
             agent.save(f"model_ep{ep}.pth")
 
     # Save final model


### PR DESCRIPTION
## Summary
- Save the DQN model every 1000 episodes during training
- Keep saving the final trained model as `model_final.pth`

## Testing
- `python -m py_compile MinecraftSelfLearningAI/train.py`


------
https://chatgpt.com/codex/tasks/task_e_689061aecb5c833180924d459713cb9c