### PR TITLE
Enhance Minecraft DQN with modern RL techniques

### DIFF
--- a/MinecraftSelfLearningAI/agent.py
+++ b/MinecraftSelfLearningAI/agent.py
@@ -1,5 +1,20 @@
+"""Agent and neural network definitions for Minecraft DQN experiments.
+
+This module provides a slightly deeper network than the original
+implementation and incorporates a number of stabilisation techniques:
+
+* Three fully-connected layers with Batch Normalisation for richer feature
+  extraction.  The network remains small enough to train quickly on CPU
+  machines such as Windows laptops.
+* Optional LSTM layer for environments that require sequence modelling.
+* Boltzmann exploration, gradient clipping and a learning-rate scheduler.
+* Double DQN targets for reduced Q-value overestimation.
+"""
+
+from __future__ import annotations
+
 import random
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 import torch
@@ -8,24 +23,45 @@ import torch.optim as optim
 
 
 class DQN(nn.Module):
-    """Simple feed-forward network used to approximate Q-values."""
+    """Feed-forward network with optional LSTM layer."""
 
-    def __init__(self, input_dim: int, output_dim: int) -> None:
+    def __init__(self, input_dim: int, output_dim: int, use_lstm: bool = False) -> None:
         super().__init__()
-        self.layers = nn.Sequential(
-            nn.Linear(input_dim, 128),
+        self.use_lstm = use_lstm
+
+        hidden = 128
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden),
+            nn.BatchNorm1d(hidden),
             nn.ReLU(),
-            nn.Linear(128, 64),
+            nn.Linear(hidden, hidden),
+            nn.BatchNorm1d(hidden),
             nn.ReLU(),
-            nn.Linear(64, output_dim),
+            nn.Linear(hidden, 64),
+            nn.BatchNorm1d(64),
+            nn.ReLU(),
         )
 
+        if use_lstm:
+            # LSTM operates on the feature dimension; batch_first makes it easy
+            # to work with single-step batches.
+            self.lstm = nn.LSTM(64, 64, batch_first=True)
+
+        self.head = nn.Linear(64, output_dim)
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        return self.layers(x)
+        if x.dim() == 1:
+            x = x.unsqueeze(0)
+        x = self.net(x)
+        if self.use_lstm:
+            x = x.unsqueeze(1)
+            x, _ = self.lstm(x)
+            x = x.squeeze(1)
+        return self.head(x)
 
 
 class DQNAgent:
-    """Deep Q-Network based agent."""
+    """Deep Q-Network based agent with Double DQN updates."""
 
     def __init__(
         self,
@@ -33,69 +69,126 @@ class DQNAgent:
         action_dim: int,
         lr: float = 1e-3,
         gamma: float = 0.99,
+        use_lstm: bool = False,
+        grad_clip: float = 1.0,
     ) -> None:
         self.action_dim = action_dim
         self.gamma = gamma
+        self.grad_clip = grad_clip
 
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-        self.policy_net = DQN(state_dim, action_dim).to(self.device)
-        self.target_net = DQN(state_dim, action_dim).to(self.device)
+        self.policy_net = DQN(state_dim, action_dim, use_lstm=use_lstm).to(self.device)
+        self.target_net = DQN(state_dim, action_dim, use_lstm=use_lstm).to(self.device)
         self.target_net.load_state_dict(self.policy_net.state_dict())
         self.target_net.eval()
 
         self.optimizer = optim.Adam(self.policy_net.parameters(), lr=lr)
-        self.loss_fn = nn.SmoothL1Loss()
+        self.scheduler = optim.lr_scheduler.StepLR(self.optimizer, step_size=10_000, gamma=0.9)
+        # Huber loss with 'none' reduction so that importance weights can be
+        # applied when using prioritized replay.
+        self.loss_fn = nn.SmoothL1Loss(reduction="none")
 
-    def select_action(self, state: Tuple[int, ...], epsilon: float) -> int:
-        """Epsilon-greedy action selection."""
+    # ------------------------------------------------------------------
+    # Action selection
+    # ------------------------------------------------------------------
+    def select_action(
+        self,
+        state: Tuple[int, ...],
+        epsilon: float = 0.0,
+        temperature: float = 1.0,
+        q_values: Optional[np.ndarray] = None,
+    ) -> int:
+        """Select an action using Boltzmann exploration.
+
+        Parameters
+        ----------
+        state : Tuple[int, ...]
+            Environment state.
+        epsilon : float, optional
+            Probability of taking a purely random action.
+        temperature : float, optional
+            Temperature parameter for the softmax exploration.  Higher values
+            yield more uniform sampling; lower values approach greedy
+            selection.
+        q_values : np.ndarray, optional
+            Pre-computed Q-values for *state* to avoid an extra forward pass.
+        """
+
         if random.random() < epsilon:
             return random.randrange(self.action_dim)
 
-        q_values = self.predict_q(state)
-        return int(np.argmax(q_values))
+        if q_values is None:
+            q_values = self.predict_q(state)
+        q_tensor = torch.tensor(q_values / max(temperature, 1e-6), dtype=torch.float32)
+        probs = torch.softmax(q_tensor, dim=0).cpu().numpy()
+        return int(np.random.choice(self.action_dim, p=probs))
 
     def predict_q(self, state: Tuple[int, ...]) -> np.ndarray:
         """Return Q-values for a given state as a NumPy array."""
+
         state_t = torch.tensor(state, dtype=torch.float32, device=self.device).unsqueeze(0)
         with torch.no_grad():
             q_values = self.policy_net(state_t).cpu().numpy()[0]
         return q_values
 
-    def train_step(self, batch) -> float:
+    # ------------------------------------------------------------------
+    # Optimisation
+    # ------------------------------------------------------------------
+    def train_step(self, batch, weights: Optional[np.ndarray] = None) -> np.ndarray:
         """Update the policy network using a batch of experience.
+
+        Parameters
+        ----------
+        batch : tuple
+            (states, actions, rewards, next_states, dones, n_steps)
+        weights : np.ndarray, optional
+            Importance-sampling weights for prioritized replay.
 
         Returns
         -------
-        float
-            Average TD error for the processed batch.
+        np.ndarray
+            TD errors for each element in the batch, useful for updating
+            priorities in a replay buffer.
         """
 
-        states, actions, rewards, next_states, dones = batch
+        states, actions, rewards, next_states, dones, n_steps = batch
 
         states_t = torch.tensor(states, dtype=torch.float32, device=self.device)
         actions_t = torch.tensor(actions, dtype=torch.long, device=self.device).unsqueeze(1)
         rewards_t = torch.tensor(rewards, dtype=torch.float32, device=self.device)
         next_states_t = torch.tensor(next_states, dtype=torch.float32, device=self.device)
         dones_t = torch.tensor(dones, dtype=torch.float32, device=self.device)
+        n_steps_t = torch.tensor(n_steps, dtype=torch.float32, device=self.device)
 
         q_values = self.policy_net(states_t).gather(1, actions_t).squeeze(1)
 
         with torch.no_grad():
-            next_q_values = self.target_net(next_states_t).max(1)[0]
-            targets = rewards_t + self.gamma * next_q_values * (1 - dones_t)
+            next_actions = self.policy_net(next_states_t).argmax(1)
+            next_q_values = self.target_net(next_states_t).gather(
+                1, next_actions.unsqueeze(1)
+            ).squeeze(1)
+            targets = rewards_t + (self.gamma ** n_steps_t) * next_q_values * (1 - dones_t)
 
         td_errors = targets - q_values
-        loss = self.loss_fn(q_values, targets)
+        losses = self.loss_fn(q_values, targets)
+        if weights is not None:
+            weights_t = torch.tensor(weights, dtype=torch.float32, device=self.device)
+            loss = (losses * weights_t).mean()
+        else:
+            loss = losses.mean()
 
         self.optimizer.zero_grad()
         loss.backward()
+        nn.utils.clip_grad_norm_(self.policy_net.parameters(), self.grad_clip)
         self.optimizer.step()
+        self.scheduler.step()
 
-        return float(td_errors.abs().mean().item())
+        return td_errors.detach().cpu().numpy()
 
     def update_target(self) -> None:
         """Synchronize target network with policy network."""
+
         self.target_net.load_state_dict(self.policy_net.state_dict())
 
     def save(self, path: str) -> None:

--- a/MinecraftSelfLearningAI/replay_buffer.py
+++ b/MinecraftSelfLearningAI/replay_buffer.py
@@ -1,15 +1,61 @@
+"""Replay buffer with optional prioritized experience and N-step returns."""
+
+from __future__ import annotations
+
 import random
 from collections import deque
-from typing import Deque, Tuple
+from typing import Deque, List, Tuple
 
 import numpy as np
 
 
 class ReplayBuffer:
-    """Fixed-size buffer to store experience tuples."""
+    """Fixed-size buffer supporting Prioritized Experience Replay and N-step returns."""
 
-    def __init__(self, capacity: int) -> None:
-        self.buffer: Deque[Tuple[np.ndarray, int, float, np.ndarray, bool]] = deque(maxlen=capacity)
+    def __init__(
+        self,
+        capacity: int,
+        gamma: float,
+        n_step: int = 1,
+        alpha: float = 0.6,
+        beta: float = 0.4,
+        beta_increment: float = 1e-6,
+    ) -> None:
+        self.capacity = capacity
+        self.gamma = gamma
+        self.n_step = n_step
+        self.alpha = alpha
+        self.beta = beta
+        self.beta_increment = beta_increment
+
+        # Main storage
+        self.buffer: List[Tuple[np.ndarray, int, float, np.ndarray, bool, int]] = []
+        self.priorities: List[float] = []
+        self.pos = 0
+
+        # Temporary buffer for N-step returns
+        self.n_step_buffer: Deque[Tuple[np.ndarray, int, float, np.ndarray, bool]] = deque(
+            maxlen=n_step
+        )
+
+    # ------------------------------------------------------------------
+    def _add(self, transition: Tuple[np.ndarray, int, float, np.ndarray, bool, int]) -> None:
+        max_prio = max(self.priorities, default=1.0)
+        if len(self.buffer) < self.capacity:
+            self.buffer.append(transition)
+            self.priorities.append(max_prio)
+        else:
+            self.buffer[self.pos] = transition
+            self.priorities[self.pos] = max_prio
+            self.pos = (self.pos + 1) % self.capacity
+
+    def _get_n_step_info(self) -> Tuple[np.ndarray, int, float, np.ndarray, bool, int]:
+        R = 0.0
+        next_state, done = self.n_step_buffer[-1][3], self.n_step_buffer[-1][4]
+        for idx, (_, _, reward, _, _) in enumerate(self.n_step_buffer):
+            R += (self.gamma ** idx) * reward
+        state, action = self.n_step_buffer[0][:2]
+        return state, action, R, next_state, done, len(self.n_step_buffer)
 
     def push(
         self,
@@ -19,13 +65,50 @@ class ReplayBuffer:
         next_state: Tuple[int, ...],
         done: bool,
     ) -> None:
-        self.buffer.append((state, action, reward, next_state, done))
+        transition = (np.array(state), action, reward, np.array(next_state), done)
+        self.n_step_buffer.append(transition)
 
+        if len(self.n_step_buffer) < self.n_step and not done:
+            return
+
+        state, action, R, next_state, done, steps = self._get_n_step_info()
+        self._add((state, action, R, next_state, done, steps))
+
+        # If episode ended, flush the remaining buffer
+        if done:
+            while self.n_step_buffer:
+                self.n_step_buffer.popleft()
+                if self.n_step_buffer:
+                    state, action, R, next_state, done, steps = self._get_n_step_info()
+                    self._add((state, action, R, next_state, done, steps))
+        else:
+            self.n_step_buffer.popleft()
+
+    # ------------------------------------------------------------------
     def sample(self, batch_size: int):
-        batch = random.sample(self.buffer, batch_size)
-        states, actions, rewards, next_states, dones = map(np.array, zip(*batch))
-        return states, actions, rewards, next_states, dones
+        if len(self.buffer) == 0:
+            raise ValueError("The replay buffer is empty")
 
+        prios = np.array(self.priorities, dtype=np.float32)
+        probs = prios ** self.alpha
+        probs /= probs.sum()
+
+        indices = np.random.choice(len(self.buffer), batch_size, p=probs)
+        samples = [self.buffer[idx] for idx in indices]
+        states, actions, rewards, next_states, dones, n_steps = map(np.array, zip(*samples))
+
+        total = len(self.buffer)
+        weights = (total * probs[indices]) ** (-self.beta)
+        weights /= weights.max()
+        self.beta = min(1.0, self.beta + self.beta_increment)
+
+        return (states, actions, rewards, next_states, dones, n_steps), indices, weights
+
+    def update_priorities(self, indices, priorities) -> None:
+        for idx, prio in zip(indices, priorities):
+            self.priorities[idx] = float(abs(prio) + 1e-6)
+
+    # ------------------------------------------------------------------
     def __len__(self) -> int:  # pragma: no cover - simple wrapper
         return len(self.buffer)
 


### PR DESCRIPTION
## Summary
- Expand DQN architecture with batch-normalised layers, optional LSTM support, Boltzmann exploration and Double DQN updates
- Add prioritized experience replay with n-step returns and importance sampling
- Update training loop with flexible epsilon/temperature schedules, larger replay buffer, higher gamma, and periodic target network updates

## Testing
- `python -m py_compile agent.py train.py replay_buffer.py env.py`
- `python - <<'PY'
from agent import DQNAgent
from env import DummyMinecraftEnv
from replay_buffer import ReplayBuffer
env=DummyMinecraftEnv()
state_dim=len(env.reset())
action_dim=4
agent=DQNAgent(state_dim, action_dim)
buffer=ReplayBuffer(100, gamma=0.995, n_step=3)
state=env.reset()
for _ in range(5):
    q_values=agent.predict_q(state)
    action=agent.select_action(state, epsilon=0.5, temperature=1.0, q_values=q_values)
    next_state, reward, done=env.step(action)
    buffer.push(state, action, reward, next_state, done)
    state=next_state
    if done:
        state=env.reset()
for _ in range(5):
    if len(buffer) < 1:
        break
    batch, idx, w = buffer.sample(1)
    td=agent.train_step(batch, w)
    buffer.update_priorities(idx, td)
print('sample td', td[:5])
PY` *(failed: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(failed: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6890c1d5c4408331894b907bb2a426e7